### PR TITLE
Update peers.py

### DIFF
--- a/scan/peers.py
+++ b/scan/peers.py
@@ -27,6 +27,10 @@ from scan.models import PeerMonitor
 
 logger = logging.getLogger(__name__)
 
+if PEERS_SCAN_DELAY > 0:
+    logger.info(f"Sleeping for {PEERS_SCAN_DELAY} seconds...")
+sleep(PEERS_SCAN_DELAY)
+
 def get_ip_by_domain(peer: str) -> str or None:
     # truncating port if exists
     if not peer.startswith("http"):
@@ -280,9 +284,5 @@ def peer_cmd():
         availability=100 - (F("downtime") / F("lifetime") * 100),
         modified_at=timezone.now(),
     )
-    if PEERS_SCAN_DELAY > 0:
-        logger.info(f"Sleeping for {PEERS_SCAN_DELAY} seconds...")
-    logger.info("Done")
-    sleep(PEERS_SCAN_DELAY)
-
+logger.info("Done")
     

--- a/scan/peers.py
+++ b/scan/peers.py
@@ -196,8 +196,12 @@ def get_nodes_list() -> list:
 
 def get_state(update: dict, peer_obj: PeerMonitor or None) -> int:
     _data = get_last_cumulative_difficulty()
-
     if update["height"] == _data["height"]:
+# TO-DO better second comparison CD drifts too much causes false forks, maybe no second needed?
+#        if update["cumulative_difficulty"] == _data["cumulative_difficulty"]:
+#            state = PeerMonitor.State.ONLINE
+#        else:
+#            state = PeerMonitor.State.FORKED
         state = PeerMonitor.State.ONLINE
     elif update["height"] > _data["height"]:
         state = PeerMonitor.State.FORKED

--- a/scan/peers.py
+++ b/scan/peers.py
@@ -198,10 +198,7 @@ def get_state(update: dict, peer_obj: PeerMonitor or None) -> int:
     _data = get_last_cumulative_difficulty()
 
     if update["height"] == _data["height"]:
-        if update["cumulative_difficulty"] == _data["cumulative_difficulty"]:
-            state = PeerMonitor.State.ONLINE
-        else:
-            state = PeerMonitor.State.FORKED
+        state = PeerMonitor.State.ONLINE
     elif update["height"] > _data["height"]:
         state = PeerMonitor.State.FORKED
     else:


### PR DESCRIPTION
Sleep has to go at the top of the script or data gets delayed by the sleep amount.    if sleep is at the bottom of the script, submitted data is always twice the sleep timer behind.  Also removed difficulty compare for online peers..   This value drifts too much and causes false forks..    need to find a better value to compare. 