### PR TITLE
container for navbar contents

### DIFF
--- a/scan/templates/base.html
+++ b/scan/templates/base.html
@@ -28,6 +28,7 @@
       {% endif %}
       <header>
         <nav class="navbar navbar-expand-lg navbar-light fixed-top bg-white border-bottom shadow mb-3">
+          <div class="container" style="max-width: 1500px !important;">
           <a class="mb-2" href="/"><img alt="LOGO" src="{% static 'logo.svg' %}" height="32px"></a>
           <a class="p-2" href="/">
             <span class="navbar-brand my-0 mr-auto mb-2 font-weight-bold">{{ 'SITE_TITLE'|env }}</span><br />
@@ -95,6 +96,7 @@
           {% else %}
           <div class="col-lg-3"></div>
           {% endif %}
+          </div>
         </nav>
       </header>
       <main role="main">

--- a/scan/templates/base.html
+++ b/scan/templates/base.html
@@ -170,15 +170,15 @@
             <span class="line" style="width: 40px;margin-bottom: 15px;"></span>
             <ul>
               <a class="normlink" href="https://discord.gg/QHZkF4KHDS" target="_blank"><i
-                  class="fab fa-discord fa-lg"></i></a>
+                  class="fab fa-discord fa-lg" data-toggle="modal" data-target="#QRModal" title="" data-original-title="Discord"></i></a>
               <a class="normlink" href="https://t.me/signumnetwork" target="_blank"><i
-                  class="fab fa-telegram-plane fa-lg"></i></a>
+                  class="fab fa-telegram-plane fa-lg" data-toggle="modal" data-target="#QRModal" title="" data-original-title="Telegram"></i></a>
               <a class="normlink" href="https://twitter.com/signum_official" target="_blank"><i
-                  class="fab fa-twitter fa-lg"></i></a>
+                  class="fab fa-twitter fa-lg" data-toggle="modal" data-target="#QRModal" title="" data-original-title="Twitter"></i></a>
               <a class="normlink" href="https://www.reddit.com/r/Signum/" target="_blank"><i
-                  class="fab fa-reddit fa-lg"></i></a>
+                  class="fab fa-reddit fa-lg" data-toggle="modal" data-target="#QRModal" title="" data-original-title="Reddit"></i></a>
               <a class="normlink" href="https://www.youtube.com/c/SignumNetwork" target="_blank"><i
-                  class="fab fa-youtube fa-lg"></i></a>
+                  class="fab fa-youtube fa-lg" data-toggle="modal" data-target="#QRModal" title="" data-original-title="YouTube"></i></a>
             </ul>
           </div>
           <div class="clearfix"></div>


### PR DESCRIPTION
keeps navbar elements centered with a little overlap from the main container, stops the logo and search from being too far on the sides, especially for large monitors.    also added tooltips for social buttons..   

before:
![image](https://user-images.githubusercontent.com/16748696/146685163-5f379af6-88a7-4de8-8074-bcd885acd122.png)

after:
![image](https://user-images.githubusercontent.com/16748696/146685177-3e7a78a6-283b-4328-bf34-d50de720b8c4.png)
