### PR TITLE
Prep-work for Node Rewards

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -42,6 +42,8 @@ AUTH_USER_MODEL = "cabinet.User"
 
 # Application definition
 
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
+
 DJANGO_APPS = [
     "django.contrib.admin",
     "django.contrib.auth",

--- a/scan/models.py
+++ b/scan/models.py
@@ -49,3 +49,4 @@ class PeerMonitor(Model):
     modified_at = DateTimeField(auto_now=True)
 
     reward_state = CharField(max_length=255, blank=True)
+    reward_time = DateTimeField(blank=True)

--- a/scan/models.py
+++ b/scan/models.py
@@ -49,4 +49,4 @@ class PeerMonitor(Model):
     modified_at = DateTimeField(auto_now=True)
 
     reward_state = CharField(max_length=255, blank=True)
-    reward_time = DateTimeField(blank=True)
+    reward_time = DateTimeField(null=True, blank=True)

--- a/scan/models.py
+++ b/scan/models.py
@@ -49,4 +49,4 @@ class PeerMonitor(Model):
     modified_at = DateTimeField(auto_now=True)
 
     reward_state = CharField(max_length=255, blank=True)
-    reward_time = DateTimeField()
+    reward_time = DateTimeField(blank=True)

--- a/scan/models.py
+++ b/scan/models.py
@@ -49,4 +49,3 @@ class PeerMonitor(Model):
     modified_at = DateTimeField(auto_now=True)
 
     reward_state = CharField(max_length=255, blank=True)
-    reward_time = DateTimeField(null=True, blank=True)

--- a/scan/models.py
+++ b/scan/models.py
@@ -47,3 +47,6 @@ class PeerMonitor(Model):
 
     created_at = DateTimeField(auto_now_add=True)
     modified_at = DateTimeField(auto_now=True)
+
+    reward_state = CharField(max_length=255, blank=True)
+    reward_time = DateTimeField()

--- a/scan/peers.py
+++ b/scan/peers.py
@@ -65,7 +65,7 @@ def get_country_by_ip(ip: str) -> str:
 class PeerMonitorForm(forms.ModelForm):
     class Meta:
         model = PeerMonitor
-        fields = "__all__"
+        fields = ['announced_address', 'platform', 'application', 'version', 'height', 'cumulative_difficulty', 'country_code', 'state', 'downtime', 'lifetime', 'availability', 'last_online_at']
 
 
 def is_good_version(version: str) -> bool:

--- a/scan/templates/peers/detail.html
+++ b/scan/templates/peers/detail.html
@@ -43,6 +43,7 @@
               <th>Platform</th>
               <td>{{ peer.platform }}</td>
             </tr>
+              {% if peer.reward_state != 'None' %}
             <tr>
               <th>Reward Status</th>
               <td>{{ peer.reward_state }}</td>
@@ -51,6 +52,7 @@
               <th>Reward Sent</th>
               <td>{{ peer.reward_time }}</td>
             </tr>
+              {% endif %}
             <tr>
               <th>Found</th>
               <td>{{ peer.created_at }} UTC</td>

--- a/scan/templates/peers/detail.html
+++ b/scan/templates/peers/detail.html
@@ -43,7 +43,7 @@
               <th>Platform</th>
               <td>{{ peer.platform }}</td>
             </tr>
-              {% if peer.reward_state != '' %}
+              {% if peer.reward_state == 'Queued' or peer.reward_state == 'Paid' or peer.reward_state == 'Duplicate' %}
             <tr>
               <th>Reward Status</th>
               <td>{{ peer.reward_state }}</td>

--- a/scan/templates/peers/detail.html
+++ b/scan/templates/peers/detail.html
@@ -44,6 +44,14 @@
               <td>{{ peer.platform }}</td>
             </tr>
             <tr>
+              <th>Reward Status</th>
+              <td>{{ peer.reward_state }}</td>
+            </tr>
+            <tr>
+              <th>Reward Sent</th>
+              <td>{{ peer.reward_time }}</td>
+            </tr>
+            <tr>
               <th>Found</th>
               <td>{{ peer.created_at }} UTC</td>
             </tr>

--- a/scan/templates/peers/detail.html
+++ b/scan/templates/peers/detail.html
@@ -43,7 +43,7 @@
               <th>Platform</th>
               <td>{{ peer.platform }}</td>
             </tr>
-              {% if peer.reward_state != 'None' %}
+              {% if peer.reward_state != '' %}
             <tr>
               <th>Reward Status</th>
               <td>{{ peer.reward_state }}</td>


### PR DESCRIPTION
prep work for the new explorer to handle payouts and let the end users see their own rewards status, if its Queued, Sent, or None aka not eligible, as well as the date and time last reward sent.       These changes can be committed now, but explorer db table "scan_peermonitor" needs two new columns added to the table.   see attached image.  "reward_state" and "reward_time"    Second screenshot shows what changes will display. 

![image](https://user-images.githubusercontent.com/16748696/148660878-c9fd0cc3-c40d-4470-ae9c-00292eb0686a.png)


![image](https://user-images.githubusercontent.com/16748696/148652126-f526adae-4fbf-481c-ab67-e647210df496.png)

