### PR TITLE
Add node sync to peer details

### DIFF
--- a/scan/templates/peers/detail.html
+++ b/scan/templates/peers/detail.html
@@ -27,6 +27,10 @@
               <th>Height</th>
               <td>{{ peer.height }}</td>
             </tr>
+            {% if progress and concensus %}<tr>
+              <th>Sync Progress</th>
+              <td>%{{ progress }}</td>
+            </tr>{% endif %}
             <tr>
               <th>Availability</th>
               <td>{{ peer.availability|floatformat:2 }}%</td>


### PR DESCRIPTION
As per request by @pir8radio added a node sync progress to the peer details page.

- After some testing adding to the peer scanner added 21 seconds of additional time to my peer scanner which was an 80% increase in time. Adding it to the peer details page makes sure only a peer in sync/stuck is checked.

- Using a consensus of the BRS_BOOTSTRAP_PEERS and the local PeerMonitor was a choice I made so that additional requests weren't being made off to those nodes, especially if someone is checking multiple nodes quickly.

- Lazy redundancy was included by only loading that portion of the peer details if both a value for progress and consensus exist.