### PR TITLE
Add section with Pools

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -16,6 +16,7 @@ from scan.views.ats import AtDetailView, AtListView
 from scan.views.blocks import BlockDetailView, BlockListView
 from scan.views.cashbacks import CBListView
 from scan.views.distribution import DistributionListView
+from scan.views.forged_blocks import ForgedBlocksListView
 from scan.views.index import index
 from scan.views.json import TopAccountsJson, getSNRjson, getStatejson
 from scan.views.marketplace import (
@@ -73,6 +74,7 @@ urlpatterns = [
     path("pools/", PoolListView.as_view(), name="pools"),
     path("pool/<str:id>", PoolDetailView.as_view(), name="pool-detail"),
     path("miner/", MinerListView.as_view(), name="miner"),
+    path("forged-blocks/", ForgedBlocksListView.as_view(), name="forged-blocks"),
     # path("admin/", admin.site.urls),
 ]
 

--- a/config/urls.py
+++ b/config/urls.py
@@ -1,60 +1,39 @@
-"""explorer URL Configuration
-
-The `urlpatterns` list routes URLs to views. For more information please see:
-    https://docs.djangoproject.com/en/2.1/topics/http/urls/
-Examples:
-Function views
-    1. Add an import:  from my_app import views
-    2. Add a URL to urlpatterns:  path('', views.home, name='home')
-Class-based views
-    1. Add an import:  from other_app.views import Home
-    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
-Including another URLconf
-    1. Import the include() function: from django.urls import include, path
-    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
-"""
 from django.conf import settings
-from django.contrib import admin
 from django.urls import include, path
 
 from scan.views.accounts import AccountsListView, AddressDetailView
+from scan.views.aliases import AliasListView
 from scan.views.assets import (
     AssetDetailView,
-    AssetMintingDetailView,
     AssetDistributionDetailView,
     AssetHoldersListView,
     AssetListView,
+    AssetMintingDetailView,
     AssetTradesListView,
     AssetTransfersListView,
-    
 )
 from scan.views.ats import AtDetailView, AtListView
 from scan.views.blocks import BlockDetailView, BlockListView
+from scan.views.cashbacks import CBListView
+from scan.views.distribution import DistributionListView
 from scan.views.index import index
+from scan.views.json import TopAccountsJson, getSNRjson, getStatejson
 from scan.views.marketplace import (
     MarketPlaceDetailView,
     MarketPlaceListView,
     MarketPlacePurchasesListView,
 )
+from scan.views.miners import MinerListView
 from scan.views.peers import (
     PeerMonitorDetailView,
     PeerMonitorListView,
     peers_charts_view,
 )
-
-from scan.views.json import (
-    getSNRjson,
-    getStatejson,
-    TopAccountsJson,
-)
-
 from scan.views.pending_transactions import pending_transactions
+from scan.views.pools import PoolDetailView, PoolListView
 from scan.views.search import search_view
-from scan.views.transactions import TxDetailView, TxListView, tx_export_csv
-from scan.views.cashbacks import CBListView
-from scan.views.aliases import AliasListView
 from scan.views.subscriptions import SubscriptionListView
-from scan.views.distribution import DistributionListView
+from scan.views.transactions import TxDetailView, TxListView, tx_export_csv
 
 urlpatterns = [
     path("", index, name="index"),
@@ -91,6 +70,9 @@ urlpatterns = [
     path("json/state/<str:address>", getStatejson, name="state"),
     path("json/accounts/", TopAccountsJson, name="json-account"),
     path("json/accounts/<int:results>", TopAccountsJson),
+    path("pools/", PoolListView.as_view(), name="pools"),
+    path("pool/<str:id>", PoolDetailView.as_view(), name="pool-detail"),
+    path("miner/", MinerListView.as_view(), name="miner"),
     # path("admin/", admin.site.urls),
 ]
 

--- a/scan/templates/base.html
+++ b/scan/templates/base.html
@@ -57,6 +57,9 @@
               <li class="nav-item">
                 <a class="nav-link" href="{% url 'blocks' %}">Blocks</a>
               </li>
+              <li class="nav-item">
+                <a class="nav-link" href="{% url 'pools' %}">Pools</a>
+              </li>
               <li class="nav-item dropdown">
                 <a class="nav-link dropdown-toggle" href="#" id="transactions-nav" data-toggle="dropdown"
                   aria-haspopup="true" aria-expanded="false">Transactions</a>

--- a/scan/templates/forged_blocks/list.html
+++ b/scan/templates/forged_blocks/list.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% load burst_tags %}
+
+{% block title %} - Forged blocks {% endblock %}
+{% block description %}
+{% if 'a' in request.GET %}Forged blocks on pool {{ request.GET.a|num2rs }}{% endif %}
+{{ paginator.count|intcomma }} Forged blocks
+{% endblock %}
+{% block content %}
+  <h5 class="p-2">Forged blocks 
+    <br class="d-md-none" />
+      {% if 'a' in request.GET %}
+      <small class="text-muted">on pool <a href="{% url 'address-detail' request.GET.a %}">{{ request.GET.a|num2rs }}</a></small>
+      {% endif %}
+  </h5>
+ 
+  <div class="card-deck mb-3">
+    <div class="card mb-4 shadow-sm">
+      <div class="card-body">
+      
+        <div class="d-flex flex-column flex-md-row align-items-center">
+          <small class="my-0 mr-md-auto text-muted">
+            {% if 'block' not in request.GET and 'a' not in request.GET %}
+              More than {{ paginator.count|intcomma }} forged blocks found<br>
+              <small>(Showing the lastest 10k records)</small>
+            {% else %}
+              A total of 
+              {% if forged_blocks %}
+                {{ paginator.count|intcomma }}
+              {% else %}
+                0
+              {% endif %}
+              forged blocks found
+              {% if 'a' in request.GET %}
+              {% endif %}
+            {% endif %}
+          </small>
+          {% include "paginator.html" %}
+        </div>
+
+        {% include "pools/forged_blocks.html" with filtered_account=request.GET.a %}
+
+        {% include "paginator.html" %}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/scan/templates/miner/list.html
+++ b/scan/templates/miner/list.html
@@ -1,0 +1,50 @@
+{% extends 'base.html' %}
+{% load humanize %}
+{% load burst_tags %}
+
+{% block title %} - Miners {% endblock %}
+{% block description %}
+{% if 'a' in request.GET %}Miners on pool {{ request.GET.a|num2rs }}{% endif %}
+{{ paginator.count|intcomma }} Miners
+{% endblock %}
+{% block content %}
+  <h5 class="p-2">Miners 
+    <br class="d-md-none" />
+      {% if 'a' in request.GET %}
+      <small class="text-muted">on pool <a href="{% url 'address-detail' request.GET.a %}">{{ request.GET.a|num2rs }}</a></small>
+      {% endif %}
+  </h5>
+ 
+  <div class="card-deck mb-3">
+    <div class="card mb-4 shadow-sm">
+      <div class="card-body">
+      
+        <div class="d-flex flex-column flex-md-row align-items-center">
+          <small class="my-0 mr-md-auto text-muted">
+            {% if 'block' not in request.GET and 'a' not in request.GET %}
+              More than {{ paginator.count|intcomma }} miners found<br>
+              <small>(Showing the lastest 10k records)</small>
+            {% else %}
+              A total of 
+              {% if miners %}
+                {{ paginator.count|intcomma }}
+              {% else %}
+                0
+              {% endif %}
+              miners found
+              {% if 'a' in request.GET %}
+              {% endif %}
+            {% endif %}
+          </small>
+          {% include "paginator.html" %}
+        </div>
+
+        {% include "pools/miners.html" with filtered_account=request.GET.a %}
+
+        {% include "paginator.html" %}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/scan/templates/pools/detail.html
+++ b/scan/templates/pools/detail.html
@@ -192,6 +192,9 @@ const template = `
               {% if miners_cnt > 0 %}
               <a class="nav-item nav-link" id="nav-miners-tab" data-toggle="tab" href="#nav-miners" role="tab" aria-controls="nav-miners" aria-selected="false">{{ miners_cnt|intcomma }} Registered miners</a>
               {% endif %}
+              {% if forged_blocks_cnt > 0 %}
+              <a class="nav-item nav-link" id="nav-blocks-tab" data-toggle="tab" href="#nav-blocks" role="tab" aria-controls="nav-blocks" aria-selected="false">{{ forged_blocks_cnt|intcomma }} Forged blocks</a>
+              {% endif %}
             </div>
           </nav>
           <div class="tab-content" id="nav-tabContent">
@@ -228,6 +231,23 @@ const template = `
               {% endif %}
                   <div class="float-right  small p-1">
                     <a href="{% url 'miner' %}?a={{ address.id }}">View all registered miners</a>
+                  </div>
+            </div>
+
+            <div class="tab-pane fade" id="nav-blocks" role="tabpanel" aria-labelledby="nav-blocks-tab">
+              {% if forged_blocks_cnt > 0 %}
+                <p class=style="margin-top: 10px">
+                  <div class="float-left small p-1">Pool has {{ forged_blocks_cnt }} forged blocks</div>
+                  <div class="float-right  small p-1">
+                    <a href="{% url 'forged-blocks' %}?a={{ address.id }}">View all forged blocks</a>
+                  </div>
+                </p>
+                {% include "pools/forged_blocks.html" %}
+              {% else %}
+                <p class="small p-1" style="margin-top: 10px">No forged blocks found</p>
+              {% endif %}
+                  <div class="float-right  small p-1">
+                    <a href="{% url 'forged-blocks' %}?a={{ address.id }}">View all forged blocks</a>
                   </div>
             </div>
 

--- a/scan/templates/pools/detail.html
+++ b/scan/templates/pools/detail.html
@@ -1,0 +1,243 @@
+{% extends 'base.html' %}
+
+{% load humanize %}
+{% load burst_tags %}
+
+{% block title %} - Pool {{ address.id|num2rs }}{% endblock %}
+
+{% block description %}
+{{ address.id|num2rs }}
+{% if address.name %}{{ address.name }}{% endif %}
+{% endblock %}
+
+{% block scripts %}
+<script>
+    var qrcode = new QRCode(document.getElementById("qr_code"), {
+        text: "{{ address.id|num2rs }}",
+        dotScale: .7,
+        backgroundImage: "/static/Signum_Logomark_blue_filled.svg",
+        backgroundImageAlpha: .3,
+        logoBackgroundTransparent: true,
+        correctLevel: QRCode.CorrectLevel.H,
+    }); 
+</script>
+
+<script>
+window.onload = function() {
+
+const template = `
+<div style='display: inline-block; text-align: center;'>
+%avatar%
+<strong>%name%</strong></div>
+<br><br>
+%description%<br> 
+<a href='%web%' target='_blank'>%web%</a>`;
+
+   const fields = document.getElementsByName('src44field');
+   if (!fields) {
+     return
+   }
+   for (const field of fields) {
+     const source = field.innerHTML;
+     try {
+       const obj = JSON.parse(source);
+       
+         const item = {
+            name: obj.nm ?? '',
+            description: obj.ds ?? '',
+            web: obj.hp ?? '',
+            avatar: ''
+         }
+       if (!obj.ds) {
+         return
+       }
+       if (obj.av) {
+           avatar = Object.keys(obj.av)[0] ?? ''
+           item.avatar = '<img src="https://cloudflare-ipfs.com/ipfs/' + avatar + '" style="width:50px; border-radius: 50%;"><br>';
+       }
+         out = template
+           .replace('%avatar%', item.avatar)
+           .replace('%name%', item.name)
+           .replace('%description%', item.description)
+           .replace(/%web%/g, item.web);
+       field.innerHTML = out;
+     } catch (_e) {
+     }
+   }
+ }
+</script>
+{% endblock %}
+
+{% block content %}
+  <!-- QRModal -->
+  <div class="modal fade" id="QRModal" tabindex="-1" role="dialog" aria-labelledby="QRModalLabel" aria-hidden="true">
+    <div class="modal-dialog modal-sm" role="document">
+      <div class="modal-content">
+        <div class="modal-header">
+          <h5 class="modal-title text-break small" id="QRModalLabel">{{ address.id|num2rs }}</h5>
+          <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        <div class="modal-body text-center">
+          <div id="qr_code" title="S-{{ address.id|num2rs }}"></div>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <h5 class="p-2">Pool<br class="d-md-none" /> {{ address.id|num2rs }}
+    <a class="btn btn-sm btn-icon btn-light rounded-circle copy-btn" href="#" data-clipboard-text="{{ address.id|num2rs }}"><i class="far fa-copy"></i></a>
+    <a class="btn btn-sm btn-icon btn-light rounded-circle" href="#" data-toggle="modal" data-target="#QRModal" title="Click to view QR Code"><i class="fa fa-qrcode"></i></a>
+    <a class="btn btn-sm btn-icon btn-light rounded-circle copy-btn" title="Click to view SignaRank" href="https://signarank.club/address/{{ address.id }}" target="_blank"><i class="fa fa-trophy"></i></a>
+  </h5>
+
+  <div class="card-deck mb-3">
+    <div class="card mb-4 shadow-sm">
+      <div class="card-body">
+
+        <div class="table-responsive">
+          <table class="table small table-sm">
+            <tbody>
+            <tr>
+              <th>Address</th>
+              <th>{{ address.id|num2rs }}
+                {% if address.is_contract %}
+                  <br class="d-md-none" />
+                  <a href="{% url 'at-detail' address.id %}"><i class="fas fa-file-code"></i>
+                    Contract details</a>
+                {% endif %}
+              </th>
+              </tr>
+            <tr>
+              <th style="width: 160px;">ID</th>
+              <th>{{ address.id }}</th>
+            </tr>
+            {% if address.name %}
+            <tr>
+              <th>Name</th>
+              <td style="word-wrap: break-word; max-width: 250px">{{ address.name }}</td>
+            </tr>
+            {% endif %}
+            {% if address.description %}
+            <tr>
+              <th style="vertical-align: top;">Description</th>
+              <td name="src44field" style="word-wrap: break-word; max-width: 250px">{{ address.description }}</td>
+            </tr>
+            {% endif %}
+            <tr>
+              <th>Total Balance</th>
+              <td>
+                {{ address.id|account_balance|burst_amount|intcomma|append_symbol }}<br class="d-md-none" />
+                <span class="text-info">(${{  address.id|account_balance|burst_amount|in_usd|floatformat:2|intcomma }} @ ${{ burst_info.exchange.price_usd|rounding:4|intcomma }} per {% coin_symbol %})</span>
+              </td>
+            </tr>
+            <tr>
+              <th>Free Balance</th>
+              <td>
+                {{address.id|account_unconfirmed_balance|burst_amount|intcomma|append_symbol }}<br class="d-md-none" />
+                <span class="text-info">(${{ address.id|account_unconfirmed_balance|burst_amount|in_usd|floatformat:2|intcomma }} @ ${{ burst_info.exchange.price_usd|rounding:4|intcomma }} per {% coin_symbol %})</span>
+              </td>
+            </tr>
+            <tr>
+              <th>Locked Balance</th>
+              <td>
+                {{address.id|account_locked_balance|burst_amount|intcomma|append_symbol }}<br class="d-md-none" />
+                <span class="text-info">(${{ address.id|account_locked_balance|burst_amount|in_usd|floatformat:2|intcomma }} @ ${{ burst_info.exchange.price_usd|rounding:4|intcomma }} per {% coin_symbol %})</span>
+              </td>
+            </tr>
+            {% if cbs_cnt > 0 %}
+            <tr>
+              <th>Total Cashback</th>
+              <td>
+                {{ total_cashback|intcomma|floatformat:5|append_symbol }}<br class="d-md-none" />
+                <span class="text-info">(${{ total_cashback|in_usd|floatformat:2|intcomma }} @ ${{ burst_info.exchange.price_usd|rounding:4|intcomma }} per {% coin_symbol %})</span>
+              </td>
+            </tr>
+            {% endif %}
+            {% if not address.is_contract %}
+            <tr>
+              <th>Public Key</th>
+              <td style="word-wrap: break-word; max-width: 250px">
+                {% if address.key_height %}
+                  <span class="text-monospace">{{ address.public_key|bin2hex }}</span>
+                  <br class="d-md-none" />
+                  at <a href="{% url 'block-detail' address.key_height %}">block {{ address.key_height }}</a>
+                {% endif %}
+              </td>
+            </tr>
+            {% endif %}
+            <tr>
+              <th>Creation Block</th>
+              <td><a href="{% url 'block-detail' address.creation_height %}">{{ address.creation_height }}</a></td>
+            </tr>
+            {% if not address.is_contract and address.pool_id %}
+            <tr>
+              <th>Pool</th>
+              <td>
+                {% if address.pool_id and address.pool_id != address.id %}
+                  {% include "account_link.html" with account_id=address.pool_id account_name=address.pool_name oneline=True %}
+                {% else %}
+                  <span class="text-success">Solo Miner</span>
+                {% endif %}
+              </td>
+            </tr>
+            {% endif %}
+            </tbody>
+          </table>
+
+          <nav>
+            <div class="nav nav-tabs small" id="nav-tab" role="tablist">
+              <a class="nav-item nav-link active" id="nav-transactions-tab" data-toggle="tab" href="#nav-transactions" role="tab" aria-controls="nav-transactions" aria-selected="true">{{ txs_cnt|intcomma }} Transactions</a>
+              {% if miners_cnt > 0 %}
+              <a class="nav-item nav-link" id="nav-miners-tab" data-toggle="tab" href="#nav-miners" role="tab" aria-controls="nav-miners" aria-selected="false">{{ miners_cnt|intcomma }} Registered miners</a>
+              {% endif %}
+            </div>
+          </nav>
+          <div class="tab-content" id="nav-tabContent">
+            <div class="tab-pane fade show active" id="nav-transactions" role="tabpanel" aria-labelledby="nav-transactions-tab">
+              {% if txs_cnt > 0 %}
+                <p style="margin-top: 10px">
+                  <div class="float-left small p-1">Latest {{ txs.count }} transactions</div>
+                  <div class="float-right  small p-1">
+                    <a href="{% url 'txs' %}?a={{ address.id }}">View all transactions</a>
+                    <a class="btn btn-sm btn-icon btn-soft-secondary rounded-circle copy-btn px-1" title="Download the latest 2k txs" href="{% url 'account-csv' address.id %}"><i class="fas fa-file-csv"></i></a>
+                  </div>
+                </p>
+                {% include "txs/list_table.html" with filtered_account=address.id %}
+                <div class="float-right  small p-1">
+                  <a href="{% url 'txs' %}?a={{ address.id }}">View all transactions</a>
+                  <a class="btn btn-sm btn-icon btn-soft-secondary rounded-circle copy-btn px-1" title="Download the latest 2k txs" href="{% url 'account-csv' address.id %}"><i class="fas fa-file-csv"></i></a>
+                </div>
+              {% else %}
+                <p class="small p-1" style="margin-top: 10px">No transactions found</p>
+              {% endif %}
+            </div>
+
+            <div class="tab-pane fade" id="nav-miners" role="tabpanel" aria-labelledby="nav-miners-tab">
+              {% if miners_cnt > 0 %}
+                <p class=style="margin-top: 10px">
+                  <div class="float-left small p-1">Pool has {{ miners_cnt }} registered miners</div>
+                  <div class="float-right  small p-1">
+                    <a href="{% url 'miner' %}?a={{ address.id }}">View all registered miners</a>
+                  </div>
+                </p>
+                {% include "pools/miners.html" %}
+              {% else %}
+                <p class="small p-1" style="margin-top: 10px">No registered miners found</p>
+              {% endif %}
+                  <div class="float-right  small p-1">
+                    <a href="{% url 'miner' %}?a={{ address.id }}">View all registered miners</a>
+                  </div>
+            </div>
+
+
+          </div>
+
+        </div>
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/scan/templates/pools/forged_blocks.html
+++ b/scan/templates/pools/forged_blocks.html
@@ -16,7 +16,7 @@
         <td><a href="{% url 'block-detail' forged_block.block %}">{{ forged_block.block }}</a></td>
         <td class="text-nowrap d-none d-sm-table-cell">{{ forged_block.block_timestamp|naturaltime }}</td>
         <td class="text-nowrap d-none d-sm-table-cell">
-            {% include "account_link.html" with account_id=forged_block.account_id account_name=forged_block.account_id|account_name_string %}
+            {% include "account_link.html" with account_id=forged_block.generator_id account_name=forged_block.generator_id|account_name_string %}
         </td>  
       </tr>
     {% endfor %}

--- a/scan/templates/pools/forged_blocks.html
+++ b/scan/templates/pools/forged_blocks.html
@@ -1,0 +1,25 @@
+{% load humanize %}
+{% load burst_tags %}
+
+<div class="table-responsive">
+  <table class="table table-hover small table-sm">
+    <thead>
+    <tr>
+      <th scope="col" class="d-none d-sm-table-cell">Forged block</th>
+      <th scope="col" class="d-none d-sm-table-cell">Timestamp</th>
+      <th scope="col" class="d-none d-sm-table-cell">Miner</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for forged_block in forged_blocks %}
+      <tr>
+        <td><a href="{% url 'block-detail' forged_block.block %}">{{ forged_block.block }}</a></td>
+        <td class="text-nowrap d-none d-sm-table-cell">{{ forged_block.block_timestamp|naturaltime }}</td>
+        <td class="text-nowrap d-none d-sm-table-cell">
+            {% include "account_link.html" with account_id=forged_block.account_id account_name=forged_block.account_id|account_name_string %}
+        </td>  
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/scan/templates/pools/list.html
+++ b/scan/templates/pools/list.html
@@ -30,22 +30,24 @@ Total: {{ paginator.count|intcomma }}
           <table class="table table-hover small table-sm">
             <thead>
             <tr>
+              <th scope="col">Last forged block</th>
+              <th scope="col">Timestamp</th>
               <th scope="col">Pool</th>
               <th scope="col">Name</th>
-              <th scope="col">Last forged block</th>
               <th scope="col">Registered miners</th>
             </tr>
             </thead>
             <tbody>
             {% for pool in pools %}
               <tr>
+                <td><a href="{% url 'block-detail' pool.height %}">{{ pool.height }}</a></td>
+                <td class="text-nowrap d-none d-sm-table-cell">{{ pool.block_timestamp|naturaltime }}</td>
                 <td><a href="{% url 'pool-detail' pool.pool_id %}">{{ pool.pool_id|num2rs }}</a></td>
                 {% if pool.url %}
                   <td><a href="{{ pool.url }}">{{ pool.pool_id|account_name_string }}</a></td>
                 {% else %}
                   <td style="word-wrap: break-word; max-width: 250px">{{ pool.pool_id|account_name_string }}</td>
                 {% endif %}
-                <td><a href="{% url 'block-detail' pool.height %}">{{ pool.height }}</a></td>
                 <td><a href="{% url 'miner' %}?a={{ pool.pool_id }}">{{ pool.miners_cnt }}</a></td>
               </tr>
             {% endfor %}

--- a/scan/templates/pools/list.html
+++ b/scan/templates/pools/list.html
@@ -1,0 +1,62 @@
+{% extends 'base.html' %}
+
+{% load humanize %}
+{% load burst_tags %}
+
+{% block title %} - Pools{% endblock %}
+{% block description %}
+Signum Pools
+Total: {{ paginator.count|intcomma }}
+{% endblock %}
+{% block content %}
+
+  <h5 class="p-2">Pools
+    {% if 'a' in request.GET %}
+    <br class="d-md-none" />
+    <small class="text-muted">for address <a href="{% url 'address-detail' request.GET.a %}">{{ request.GET.a|num2rs }}</a></small>
+    {% endif %}
+  </h5>
+
+  <div class="card-deck mb-3">
+    <div class="card mb-4 shadow-sm">
+      <div class="card-body">
+
+        <div class="d-flex flex-column flex-md-row align-items-center">
+          <small class="my-0 mr-md-auto text-muted">{{ paginator.count|intcomma }} Pools found</small>
+          {% include "paginator.html" %}
+        </div>
+
+        <div class="table-responsive">
+          <table class="table table-hover small table-sm">
+            <thead>
+            <tr>
+              <th scope="col">Pool</th>
+              <th scope="col">Name</th>
+              <th scope="col">Last forged block</th>
+              <th scope="col">Registered miners</th>
+            </tr>
+            </thead>
+            <tbody>
+            {% for pool in pools %}
+              <tr>
+                <td><a href="{% url 'pool-detail' pool.pool_id %}">{{ pool.pool_id|num2rs }}</a></td>
+                {% if pool.url %}
+                  <td><a href="{{ pool.url }}">{{ pool.pool_id|account_name_string }}</a></td>
+                {% else %}
+                  <td style="word-wrap: break-word; max-width: 250px">{{ pool.pool_id|account_name_string }}</td>
+                {% endif %}
+                <td><a href="{% url 'block-detail' pool.height %}">{{ pool.height }}</a></td>
+                <td><a href="{% url 'miner' %}?a={{ pool.pool_id }}">{{ pool.miners_cnt }}</a></td>
+              </tr>
+            {% endfor %}
+            </tbody>
+          </table>
+        </div>
+
+        {% include "paginator.html" %}
+
+      </div>
+    </div>
+  </div>
+
+{% endblock %}

--- a/scan/templates/pools/miners.html
+++ b/scan/templates/pools/miners.html
@@ -5,17 +5,19 @@
   <table class="table table-hover small table-sm">
     <thead>
     <tr>
+      <th scope="col" class="d-none d-sm-table-cell">Forged block</th>
+      <th scope="col" class="d-none d-sm-table-cell">Timestamp</th>
       <th scope="col" class="d-none d-sm-table-cell">Miner</th>
-      <th scope="col">Since Block</th>
     </tr>
     </thead>
     <tbody>
     {% for miner in miners %}
       <tr>
+        <td><a href="{% url 'block-detail' miner.height %}">{{ miner.height }}</a></td>
+        <td class="text-nowrap d-none d-sm-table-cell">{{ miner.block_timestamp|naturaltime }}</td>
         <td class="text-nowrap d-none d-sm-table-cell">
           {% include "account_link.html" with account_id=miner.account_id account_name=miner.account_id|account_name_string %}
-        </td>
-        <td><a href="{% url 'block-detail' miner.height %}">{{ miner.height }}</a></td>
+        </td>        
       </tr>
     {% endfor %}
     </tbody>

--- a/scan/templates/pools/miners.html
+++ b/scan/templates/pools/miners.html
@@ -1,0 +1,23 @@
+{% load humanize %}
+{% load burst_tags %}
+
+<div class="table-responsive">
+  <table class="table table-hover small table-sm">
+    <thead>
+    <tr>
+      <th scope="col" class="d-none d-sm-table-cell">Miner</th>
+      <th scope="col">Since Block</th>
+    </tr>
+    </thead>
+    <tbody>
+    {% for miner in miners %}
+      <tr>
+        <td class="text-nowrap d-none d-sm-table-cell">
+          {% include "account_link.html" with account_id=miner.account_id account_name=miner.account_id|account_name_string %}
+        </td>
+        <td><a href="{% url 'block-detail' miner.height %}">{{ miner.height }}</a></td>
+      </tr>
+    {% endfor %}
+    </tbody>
+  </table>
+</div>

--- a/scan/templatetags/burst_tags.py
+++ b/scan/templatetags/burst_tags.py
@@ -443,7 +443,8 @@ def account_locked_balance(account_id : int) -> float:
 @cache_memoize(240)
 @register.filter
 def account_name_string(account_id : int) -> float:
-    return get_account_name(account_id)
+    account_name = get_account_name(account_id)
+    return account_name if account_name else ''
 
 @register.filter
 def asset_price(asset_id : int) -> float:

--- a/scan/views/forged_blocks.py
+++ b/scan/views/forged_blocks.py
@@ -1,0 +1,43 @@
+from django.db.models import F, OuterRef, Q
+from django.views.generic import ListView
+
+from java_wallet.models import Block, RewardRecipAssign
+from scan.caching_paginator import CachingPaginator
+from scan.views.pools import get_timestamp_of_block
+
+
+class ForgedBlocksListView(ListView):
+    model = RewardRecipAssign
+    queryset = (
+        RewardRecipAssign.objects.using("java_wallet")
+        .filter(~Q(recip_id=F('account_id')))
+        .annotate(
+            block=Block.objects.using("java_wallet")
+            .filter(generator_id=OuterRef("account_id"))
+            .order_by("-height")
+            .values("height")
+            [:1]
+        )
+        .values("recip_id", "account_id", "block")
+        .exclude(block__isnull=True)
+        .exclude(recip_id__isnull=True)
+        )
+    template_name = "forged_blocks/list.html"
+    context_object_name = "forged_blocks"
+    paginator_class = CachingPaginator
+    paginate_by = 25
+    ordering = "-block"
+
+    def get_queryset(self):
+        qs = self.queryset
+        qs = qs.filter(latest=True)
+        if 'a' in self.request.GET:
+            qs = qs.filter(recip_id=self.request.GET['a'], latest=1)
+        return qs.order_by(self.ordering)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        obj = context[self.context_object_name]
+        for forget_block in obj:
+            forget_block["block_timestamp"] = get_timestamp_of_block(forget_block["block"])
+        return context

--- a/scan/views/forged_blocks.py
+++ b/scan/views/forged_blocks.py
@@ -38,6 +38,6 @@ class ForgedBlocksListView(ListView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         obj = context[self.context_object_name]
-        for forget_block in obj:
-            forget_block["block_timestamp"] = get_timestamp_of_block(forget_block["block"])
+        for forged_block in obj:
+            forged_block["block_timestamp"] = get_timestamp_of_block(forged_block["block"])
         return context

--- a/scan/views/forged_blocks.py
+++ b/scan/views/forged_blocks.py
@@ -3,7 +3,7 @@ from django.views.generic import ListView
 
 from java_wallet.models import Block, RewardRecipAssign
 from scan.caching_paginator import CachingPaginator
-from scan.views.pools import get_timestamp_of_block
+from scan.helpers.queries import get_timestamp_of_block
 
 
 class ForgedBlocksListView(ListView):

--- a/scan/views/miners.py
+++ b/scan/views/miners.py
@@ -1,0 +1,25 @@
+from django.views.generic import ListView
+
+from java_wallet.models import RewardRecipAssign
+from scan.caching_paginator import CachingPaginator
+
+
+class MinerListView(ListView):
+    model = RewardRecipAssign
+    queryset = RewardRecipAssign.objects.using("java_wallet").all()
+    template_name = "miner/list.html"
+    context_object_name = "miners"
+    paginator_class = CachingPaginator
+    paginate_by = 25
+    ordering = "-height"
+
+    def get_queryset(self):
+        qs = self.queryset
+        qs = qs.filter(latest=True)
+        if 'a' in self.request.GET:
+            qs = qs.filter(recip_id=self.request.GET['a'], latest=1)
+        return qs.order_by(self.ordering)
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        return context

--- a/scan/views/miners.py
+++ b/scan/views/miners.py
@@ -3,7 +3,7 @@ from django.views.generic import ListView
 
 from java_wallet.models import RewardRecipAssign
 from scan.caching_paginator import CachingPaginator
-from scan.views.pools import get_timestamp_of_block
+from scan.helpers.queries import get_timestamp_of_block
 
 
 class MinerListView(ListView):

--- a/scan/views/peers.py
+++ b/scan/views/peers.py
@@ -92,14 +92,14 @@ class PeerMonitorDetailView(DetailView):
         context = super().get_context_data(**kwargs)
         obj = context[self.context_object_name]
 
-        if obj.state == 3 or 4: # 4 could be removed if we only want sync
+        if obj.state == 3 or obj.state == 4: # 4 could be removed if we only want sync
             featured_peers = []
             for peer in BRS_BOOTSTRAP_PEERS:
-                featured_peer = PeerMonitor.objects.filter(announced_address=peer).values("height").first()
+                featured_peer = PeerMonitor.objects.filter(announced_address=peer).exclude(state__gt=1).values("height").first()
                 if featured_peer:
                     featured_peers.append(featured_peer["height"])
 
             context["concensus"] = round(sum(featured_peers)/len(featured_peers))
-            context["progress"] = round((obj.height / context["concensus"]) * 100, 2)
+            context["progress"] = str(round((obj.height / context["concensus"]) * 100, 2))
 
         return context

--- a/scan/views/pools.py
+++ b/scan/views/pools.py
@@ -19,6 +19,8 @@ from scan.views.transactions import fill_data_transaction
 def fill_data_pool(pool):
     pool["url"] = get_description_url(pool["pool_id"])
     pool["miners_cnt"] = get_count_of_miners(pool["pool_id"])
+    pool["forged_block_cnt"] = get_count_forged_blocks_of_pool(pool["pool_id"])
+    pool["block_timestamp"] = get_timestamp_of_block(pool["height"])
 
 
 def get_description_url(pool_id):
@@ -38,7 +40,8 @@ def get_description_url(pool_id):
 def get_count_of_miners(pool_id):
     return (
         RewardRecipAssign.objects.using("java_wallet")
-        .filter(recip_id=pool_id, latest=1)
+        .filter(recip_id=pool_id)
+        .filter(latest=1)
     ).count()
 
 
@@ -49,6 +52,26 @@ def get_timestamp_of_block(height):
         .values_list("timestamp", flat=True)
         .first()
     )
+
+
+def get_count_forged_blocks_of_pool(pool_id):
+    return (
+        RewardRecipAssign.objects.using("java_wallet")
+        .filter(~Q(recip_id=F('account_id')))
+        .annotate(
+            block=Block.objects.using("java_wallet")
+            .filter(generator_id=OuterRef("account_id"))
+            .order_by("-height")
+            .values("height")
+            [:1]
+        )
+        .order_by("-block")
+        .values("recip_id", "account_id", "block")
+        .exclude(block__isnull=True)
+        .exclude(recip_id__isnull=True)
+        .filter(latest=1)
+        .filter(recip_id=pool_id)
+    ).count()
 
 
 class PoolListView(ListView):

--- a/scan/views/pools.py
+++ b/scan/views/pools.py
@@ -1,0 +1,173 @@
+import json
+
+from django.db.models import F, OuterRef, Q
+from django.views.generic import ListView
+
+from java_wallet.models import (
+    Account,
+    Block,
+    IndirectIncoming,
+    RewardRecipAssign,
+    Transaction,
+)
+from scan.caching_paginator import CachingPaginator
+from scan.helpers.queries import get_account_name
+from scan.views.base import IntSlugDetailView
+from scan.views.transactions import fill_data_transaction
+
+
+def fill_data_pool(pool):
+    pool["url"] = get_description_url(pool["pool_id"])
+    pool["miners_cnt"] = get_count_of_miners(pool["pool_id"])
+
+
+def get_description_url(pool_id):
+    description = (
+        Account.objects.using("java_wallet")
+        .filter(id=pool_id)
+        .values_list("description", flat=True)
+        .first()
+    )
+    try:
+        return json.loads(description)["hp"]
+    except (json.JSONDecodeError, TypeError, KeyError):
+        return ''
+
+
+def get_count_of_miners(pool_id):
+    return (
+        RewardRecipAssign.objects.using("java_wallet")
+        .filter(recip_id=pool_id, latest=1)
+    ).count()
+
+
+class PoolListView(ListView):
+    model = RewardRecipAssign
+    queryset = (
+        RewardRecipAssign.objects.using("java_wallet")
+        .filter(~Q(recip_id=F('account_id')))
+        .values("recip_id", "account_id")
+    )
+    template_name = "pools/list.html"
+    context_object_name = "pools"
+    paginator_class = CachingPaginator
+    paginate_by = 25
+    ordering = "-block"
+
+    def get_queryset(self):
+        qs = self.queryset
+        query_block = (
+            Block.objects.using("java_wallet")
+            .values("generator_id", "height")
+            .all()
+        )
+        query_from_query_block = (
+            query_block
+            .annotate(
+                pool_id=qs
+                .filter(height__lte=OuterRef("height"))
+                .filter(account_id=OuterRef("generator_id"))
+                .order_by("-height")
+                .values("recip_id")
+                [:1]
+            )
+            .order_by("-height")
+            .values("pool_id", "height")
+            .exclude(height__isnull=True)
+            .exclude(pool_id__isnull=True)
+        )
+        query_from_queryset = (
+            qs
+            .annotate(
+                block=query_block
+                .filter(generator_id=OuterRef("account_id"))
+                .order_by("-height")
+                .values("height")
+                [:1]
+            )
+            .order_by("-block")
+            .values("recip_id", "block")
+            .exclude(block__isnull=True)
+            .exclude(recip_id__isnull=True)
+        )
+
+        pool_s_last_forged_blocks = []
+        pools_list = []
+        for query in query_from_queryset:
+            if query["recip_id"] not in pools_list:
+                pool_s_last_forged_blocks.append(query["block"])
+                pools_list.append(query["recip_id"])
+
+        return (
+            query_from_query_block
+            .filter(height__in=pool_s_last_forged_blocks)
+        )
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        obj = context[self.context_object_name]
+
+        for pool in obj:
+            fill_data_pool(pool)
+
+        return context
+
+
+class PoolDetailView(IntSlugDetailView):
+    model = Account
+    queryset = Account.objects.using("java_wallet").filter(latest=True).all()
+    template_name = "pools/detail.html"
+    context_object_name = "address"
+    slug_field = "id"
+    slug_url_kwarg = "id"
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        obj = context[self.context_object_name]
+
+        # To also show contract names when checking as an account
+        if not obj.name:
+            obj.name = get_account_name(obj.id)
+
+        # transactions
+        indirects_query = (
+            IndirectIncoming.objects.using("java_wallet")
+            .values_list('transaction_id', flat=True)
+            .filter(account_id=obj.id)
+        )
+        indirects_count = indirects_query.count()
+
+        txs_query = (
+            Transaction.objects.using("java_wallet")
+            .filter(Q(sender_id=obj.id) | Q(recipient_id=obj.id))
+        )
+        txs_cnt = txs_query.count() + indirects_count
+
+        if indirects_count > 0:
+            txs_indirects = (
+                Transaction.objects.using("java_wallet")
+                .filter(id__in=indirects_query)
+            )
+            txs_query = txs_query.union(txs_indirects)
+
+        txs = txs_query.order_by("-height")[:min(txs_cnt, 15)]
+
+        for t in txs:
+            fill_data_transaction(t, list_page=True)
+
+        context["txs"] = txs
+        context["txs_cnt"] = txs_cnt
+
+        # Miners
+
+        miners_query = (
+            RewardRecipAssign.objects.using("java_wallet")
+            .filter(recip_id=obj.id, latest=1)
+        )
+
+        miners = miners_query.order_by('-height')
+
+        context["miners"] = miners[:25]
+        context["miners_cnt"] = get_count_of_miners(obj.id)
+
+        return context

--- a/scan/views/pools.py
+++ b/scan/views/pools.py
@@ -26,6 +26,7 @@ def get_description_url(pool_id):
         Account.objects.using("java_wallet")
         .filter(id=pool_id)
         .values_list("description", flat=True)
+        .filter(latest=1)
         .first()
     )
     try:


### PR DESCRIPTION
1) A section with a list of pools sorted by the last forged block has been added to the navigation. There is also the number of registered miners on each pool.
![image](https://github.com/signum-network/signum-explorer/assets/57628432/3a8510a1-36a4-4d7f-b18e-717d157bd3f5)

2) Clicking on the pool address opens a page with detailed data on the pool with sections: Transactions and registered miners.
![image](https://github.com/signum-network/signum-explorer/assets/57628432/8d69ab93-2a0c-4d92-abef-fac91c4927e9)

3) By clicking on the number of miners on the Pools homepage, a list of all registered miners opens.
