### PR TITLE
Added ability to automatically set featured nodes

### DIFF
--- a/config/settings.py
+++ b/config/settings.py
@@ -260,8 +260,8 @@ GOOGLE_TRACKING_ID = os.environ.get("GOOGLE_TRACKING_ID")
 DEFAULT_P2P_PORT = int(os.environ.get("DEFAULT_P2P_PORT", 8123))
 DEFAULT_API_V1_PORT = int(os.environ.get("DEFAULT_API_V1_PORT", 8125))
 
-BRS_P2P_VERSION = os.environ.get("BRS_P2P_VERSION", "3.2.1")
-MIN_PEER_VERSION = os.environ.get("MIN_PEER_VERSION", "3.2.0")
+BRS_P2P_VERSION = os.environ.get("BRS_P2P_VERSION", "3.7.2")
+MIN_PEER_VERSION = os.environ.get("MIN_PEER_VERSION", "3.6.0")
 
 SIGNUM_NODE = os.environ.get("SIGNUM_NODE")
 
@@ -276,6 +276,7 @@ BLOCKED_ASSETS = json.loads(os.environ.get("BLOCKED_ASSETS", "[]"))
 PHISHING_ASSETS = json.loads(os.environ.get("PHISHING_ASSETS", "[]"))
 
 BRS_BOOTSTRAP_PEERS = json.loads(os.environ.get("BRS_BOOTSTRAP_PEERS", "[]"))
+AUTO_BOOTSTRAP_PEERS = str(os.environ.get("AUTO_BOOTSTRAP_PEERS", "on"))
 
 PEERS_SCAN_DELAY = int(os.environ.get("PEERS_SCAN_DELAY", "0"))
 TASKS_SCAN_DELAY = int(os.environ.get("TASKS_SCAN_DELAY", "0"))

--- a/scan/views/peers.py
+++ b/scan/views/peers.py
@@ -2,7 +2,7 @@ from django.db.models import Count
 from django.shortcuts import render
 from django.views.decorators.http import require_http_methods
 from django.views.generic import DetailView, ListView
-from config.settings import BRS_BOOTSTRAP_PEERS
+from config.settings import BRS_BOOTSTRAP_PEERS, AUTO_BOOTSTRAP_PEERS
 from django.http import HttpResponse
 from scan.models import PeerMonitor
 import json
@@ -69,7 +69,15 @@ class PeerMonitorListView(ListView):
         context = super().get_context_data(**kwargs)
 
         featured_peers = []
-        for peer in BRS_BOOTSTRAP_PEERS:
+        bootstrap_peers = BRS_BOOTSTRAP_PEERS
+        if AUTO_BOOTSTRAP_PEERS.upper() == ('ON' or 'TRUE'):
+            bootstrap_peers = (
+                PeerMonitor.objects
+                .filter(announced_address__contains='.signum.network')
+                .exclude(state__gt=1)
+                .values_list(flat=True)
+            )
+        for peer in bootstrap_peers:
             featured_peer = (PeerMonitor.objects.filter(announced_address=peer)
                 .order_by("-availability").first())
             if featured_peer:


### PR DESCRIPTION
Added AUTO_BOOTSTRAP_PEERS to allow explorer to automaically gather the *.signum.network peers

-feature can be disabled by setting AUTO_BOOTSTRAP_PEERS to anything other than on or true in the env
-if this feature is on, BRS_BOOTSTRAP_PEERS is ignored*
*if BRS_BOOTSTRAP_PEERS is empty and AUTO_BOOTSTRAP_PEERS is off, the explorer featured peers will be empty