### PR TITLE
Fix incorrect requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,24 +1,42 @@
-# other required packages, manually install using apt. tested with redis-server v7 and python 3.10
-# apt install python3-dev default-libmysqlclient-dev build-essential redis-server supervisor
-
-# required packages  to use 'pip install -r requirements.txt'
-python
-django
-django-cache-memoize
-django-cors-headers
-django-filter
-django-redis
-djangorestframework
-gunicorn
-jsonschema
-mysqlclient
-requests
-sentry-sdk
-simplejson
-supervisor
-whitenoise
-python-dotenv
-
-# required packages specific versions
-# minimum version of pycoingecko needed
+amqp==5.2.0
+asgiref==3.7.2
+async-timeout==4.0.3
+attrs==23.1.0
+billiard==4.2.0
+celery==5.3.5
+certifi==2023.11.17
+charset-normalizer==3.3.2
+click==8.1.7
+click-didyoumean==0.3.0
+click-plugins==1.1.1
+click-repl==0.3.0
+Django==4.2.7
+django-cache-memoize==0.2.0
+django-cors-headers==4.3.1
+django-filter==23.4
+django-redis==5.4.0
+djangorestframework==3.14.0
+gunicorn==21.2.0
+idna==3.4
+jsonschema==4.20.0
+jsonschema-specifications==2023.11.1
+kombu==5.3.4
+mysqlclient==2.2.0
+packaging==23.2
+prompt-toolkit==3.0.41
 pycoingecko==3.1.0
+python-dateutil==2.8.2
+python-dotenv==1.0.0
+pytz==2023.3.post1
+redis==5.0.1
+referencing==0.31.0
+requests==2.31.0
+rpds-py==0.13.1
+simplejson==3.19.2
+six==1.16.0
+sqlparse==0.4.4
+tzdata==2023.3
+urllib3==2.1.0
+vine==5.1.0
+wcwidth==0.2.10
+whitenoise==6.6.0


### PR DESCRIPTION
Current file `requirements.txt` it contains unnecessary and incorrect information, for example, `python` on 5 line.
I offer my version `requirements.txt` with which the `pip install -r requirements.txt` command can install the necessary packages to start and work signum explorer.